### PR TITLE
Fix context load test to run with Testcontainers

### DIFF
--- a/backend/src/test/java/com/example/springbootprojet/SpringBootProjectApplicationTests.java
+++ b/backend/src/test/java/com/example/springbootprojet/SpringBootProjectApplicationTests.java
@@ -2,9 +2,16 @@ package com.example.springbootprojet;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import com.example.springbootprojet.AbstractTestContainers;
+
+/**
+ * Basic context load test that leverages the Testcontainers based setup.
+ * Extending {@link AbstractTestContainers} ensures a PostgreSQL container is
+ * started so the Spring context can initialise successfully.
+ */
 
 @SpringBootTest
-class SpringBootProjectApplicationTests {
+class SpringBootProjectApplicationTests extends AbstractTestContainers {
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
## Summary
- ensure `SpringBootProjectApplicationTests` uses `AbstractTestContainers`
- document the reason in code comment

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6848cd9a082c8322ae77adad61a0415c