### PR TITLE
Fix backend CI workflow environment

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,12 +9,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DB_URL: jdbc:postgresql://localhost:5332/customer
+      DB_USERNAME: anassabbou
+      DB_PASSWORD: password
     services:
       postgres:
         image: postgres:latest
         env:
-          POSTGRES_USER: anassabbou
-          POSTGRES_PASSWORD: password
+          POSTGRES_USER: ${{ env.DB_USERNAME }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
           POSTGRES_DB: customer
         ports:
           - 5332:5432
@@ -32,7 +36,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '17'
           cache: 'maven'
-      - name: Build and run Unit/integration Testes with maven
-        run: mvn -ntp -B verify # Download all debps & plugins
+      - name: Build and run Unit/integration Tests with Maven
+        run: mvn -ntp -B verify # Download all deps & plugins

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -91,26 +91,9 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>pre-integration-test</id>
-                        <goals>
-                            <goal>start</goal>
-                        </goals>
-
-                    <configuration>
-                        <arguments>
-                            <argument>--server.port=${tomcat.http.port}</argument>
-                        </arguments>
-                    </configuration>
-                    </execution>
-                    <execution>
-                        <id>post-integration-test</id>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <!-- Integration tests already start the application using
+                     @SpringBootTest, so the plugin's start/stop goals are
+                     unnecessary and can cause failures on CI -->
                 <configuration>
                     <excludes>
                         <exclude>


### PR DESCRIPTION
## Summary
- set database environment variables for integration tests
- use Java 17 for maven builds
- correct workflow step names
- remove Spring Boot plugin's start/stop goals so integration tests run correctly

## Testing
- `mvn -ntp -B verify` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_6848b8a06b4c8322b9fb39ec8af440b2